### PR TITLE
Task #229704 Remove Batch ID Column from Content Tracking and Assessment Tracking Tables and Backend APIs in Tracking Microservice

### DIFF
--- a/src/modules/tracking_assessment/dto/tracking-assessment-create-dto.ts
+++ b/src/modules/tracking_assessment/dto/tracking-assessment-create-dto.ts
@@ -35,15 +35,6 @@ export class CreateAssessmentTrackingDto {
 
     @ApiPropertyOptional({
         type: () => String,
-        description: "Batch Id",
-    })
-    @Expose()
-    @IsString()
-    @IsNotEmpty()
-    batchId: string;
-
-    @ApiPropertyOptional({
-        type: () => String,
         description: "Content values",
     })
     @Expose()

--- a/src/modules/tracking_assessment/dto/tracking-assessment-search-dto.ts
+++ b/src/modules/tracking_assessment/dto/tracking-assessment-search-dto.ts
@@ -57,16 +57,6 @@ export class setFilters {
 
   @ApiPropertyOptional({
     type: () => String,
-    description: "Batch Id",
-  })
-  @Expose()
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
-  batchId: string;
-
-  @ApiPropertyOptional({
-    type: () => String,
     description: "Content values",
   })
   @Expose()

--- a/src/modules/tracking_assessment/entities/tracking-assessment-entity.ts
+++ b/src/modules/tracking_assessment/entities/tracking-assessment-entity.ts
@@ -12,9 +12,6 @@ export class AssessmentTracking {
   courseId: string;
 
   @Column()
-  batchId: string;
-
-  @Column()
   contentId: string;
 
   @Column()

--- a/src/modules/tracking_assessment/tracking_assessment.service.ts
+++ b/src/modules/tracking_assessment/tracking_assessment.service.ts
@@ -112,7 +112,6 @@ export class TrackingAssessmentService {
         'assessmentTrackingId',
         'userId',
         'courseId',
-        'batchId',
         'contentId',
         'attemptId',
         'createdOn',
@@ -213,11 +212,10 @@ export class TrackingAssessmentService {
     try {
       let output_result = [];
       const result = await this.dataSource.query(
-        `SELECT "assessmentTrackingId","userId","courseId","batchId","contentId","attemptId","createdOn","lastAttemptedOn","totalMaxScore","totalScore","updatedOn","timeSpent","unitId" FROM assessment_tracking WHERE "userId"=$1 and "contentId"=$2 and "batchId"=$3 and "courseId"=$4 and "unitId"=$5`,
+        `SELECT "assessmentTrackingId","userId","courseId","contentId","attemptId","createdOn","lastAttemptedOn","totalMaxScore","totalScore","updatedOn","timeSpent","unitId" FROM assessment_tracking WHERE "userId"=$1 and "contentId"=$2 and "courseId"=$3 and "unitId"=$4`,
         [
           searchFilter?.userId,
           searchFilter?.contentId,
-          searchFilter?.batchId,
           searchFilter?.courseId,
           searchFilter?.unitId,
         ],
@@ -294,7 +292,6 @@ export class TrackingAssessmentService {
                   "assessmentTrackingId",
                   "userId",
                   "courseId",
-                  "batchId",
                   "contentId",
                   "attemptId",
                   "createdOn",
@@ -304,7 +301,7 @@ export class TrackingAssessmentService {
                   "updatedOn",
                   "timeSpent",
                   "unitId",
-                  ROW_NUMBER() OVER (PARTITION BY "userId", "batchId", "courseId", "unitId", "contentId" ORDER BY "createdOn" DESC) as row_num
+                  ROW_NUMBER() OVER (PARTITION BY "userId", "courseId", "unitId", "contentId" ORDER BY "createdOn" DESC) as row_num
               FROM 
                   assessment_tracking
               WHERE 
@@ -312,13 +309,11 @@ export class TrackingAssessmentService {
                   AND "courseId" IN (${courseId_text}) 
                   AND "unitId" IN (${unitId_text}) 
                   AND "contentId" IN (${contentId_text}) 
-                  AND "batchId" = $2
           )
           SELECT 
               "assessmentTrackingId",
               "userId",
               "courseId",
-              "batchId",
               "contentId",
               "attemptId",
               "createdOn",
@@ -332,7 +327,7 @@ export class TrackingAssessmentService {
               latest_assessment
           WHERE 
               row_num = 1;`,
-          [userId, searchFilter?.batchId],
+          [userId],
         );
         for (let j = 0; j < result.length; j++) {
           let temp_result = result[j];
@@ -399,7 +394,6 @@ export class TrackingAssessmentService {
         'userId',
         'courseId',
         'unitId',
-        'batchId',
         'contentId',
       ];
       const paginationKeys = ['pageSize', 'page'];
@@ -409,7 +403,6 @@ export class TrackingAssessmentService {
         'assessmentTrackingId',
         'userId',
         'courseId',
-        'batchId',
         'contentId',
         'attemptId',
         'createdOn',

--- a/src/modules/tracking_content/dto/tracking-content-create-dto.ts
+++ b/src/modules/tracking_content/dto/tracking-content-create-dto.ts
@@ -35,15 +35,6 @@ export class CreateContentTrackingDto {
 
   @ApiPropertyOptional({
     type: () => String,
-    description: 'Batch Id',
-  })
-  @Expose()
-  @IsString()
-  @IsNotEmpty()
-  batchId: string;
-
-  @ApiPropertyOptional({
-    type: () => String,
     description: 'Content values',
   })
   @Expose()

--- a/src/modules/tracking_content/dto/tracking-content-search-dto.ts
+++ b/src/modules/tracking_content/dto/tracking-content-search-dto.ts
@@ -47,16 +47,6 @@ export class setFilters {
 
   @ApiPropertyOptional({
     type: () => String,
-    description: "Batch Id",
-  })
-  @Expose()
-  @IsString()
-  @IsOptional()
-  @IsNotEmpty()
-  batchId: string;
-
-  @ApiPropertyOptional({
-    type: () => String,
     description: "Content values",
   })
   @Expose()

--- a/src/modules/tracking_content/entities/tracking-content-entity.ts
+++ b/src/modules/tracking_content/entities/tracking-content-entity.ts
@@ -12,9 +12,6 @@ export class ContentTracking {
   courseId: string;
 
   @Column()
-  batchId: string;
-
-  @Column()
   contentId: string;
 
   @Column()

--- a/src/modules/tracking_content/tracking_content.service.ts
+++ b/src/modules/tracking_content/tracking_content.service.ts
@@ -112,7 +112,6 @@ export class TrackingContentService {
         'contentTrackingId',
         'userId',
         'courseId',
-        'batchId',
         'contentId',
         'contentType',
         'contentMime',
@@ -152,11 +151,10 @@ export class TrackingContentService {
 
       //find contentTracking
       const result_content = await this.dataSource.query(
-        `SELECT "contentTrackingId" FROM content_tracking WHERE "userId"=$1 and "contentId"=$2 and "batchId"=$3 and "courseId"=$4 and "unitId"=$5`,
+        `SELECT "contentTrackingId" FROM content_tracking WHERE "userId"=$1 and "contentId"=$2 and "courseId"=$3 and "unitId"=$4`,
         [
           createContentTrackingDto?.userId,
           createContentTrackingDto?.contentId,
-          createContentTrackingDto?.batchId,
           createContentTrackingDto?.courseId,
           createContentTrackingDto?.unitId,
         ],
@@ -234,11 +232,10 @@ export class TrackingContentService {
     try {
       let output_result = [];
       const result = await this.dataSource.query(
-        `SELECT "contentTrackingId","userId","courseId","batchId","contentId","contentType","contentMime","createdOn","lastAccessOn","updatedOn","unitId" FROM content_tracking WHERE "userId"=$1 and "contentId"=$2 and "batchId"=$3 and "courseId"=$4 and "unitId"=$5`,
+        `SELECT "contentTrackingId","userId","courseId","contentId","contentType","contentMime","createdOn","lastAccessOn","updatedOn","unitId" FROM content_tracking WHERE "userId"=$1 and "contentId"=$2 and "courseId"=$3 and "unitId"=$4`,
         [
           searchFilter?.userId,
           searchFilter?.contentId,
-          searchFilter?.batchId,
           searchFilter?.courseId,
           searchFilter?.unitId,
         ],
@@ -315,7 +312,6 @@ export class TrackingContentService {
                   "contentTrackingId",
                   "userId",
                   "courseId",
-                  "batchId",
                   "contentId",
                   "contentType",
                   "contentMime",
@@ -323,7 +319,7 @@ export class TrackingContentService {
                   "lastAccessOn",
                   "updatedOn",
                   "unitId",
-                  ROW_NUMBER() OVER (PARTITION BY "userId", "batchId", "courseId", "unitId", "contentId" ORDER BY "createdOn" DESC) as row_num
+                  ROW_NUMBER() OVER (PARTITION BY "userId", "courseId", "unitId", "contentId" ORDER BY "createdOn" DESC) as row_num
               FROM 
                   content_tracking
               WHERE 
@@ -331,13 +327,11 @@ export class TrackingContentService {
                   AND "courseId" IN (${courseId_text}) 
                   AND "unitId" IN (${unitId_text}) 
                   AND "contentId" IN (${contentId_text}) 
-                  AND "batchId" = $2
           )
           SELECT 
               "contentTrackingId",
               "userId",
               "courseId",
-              "batchId",
               "contentId",
               "contentType",
               "contentMime",
@@ -349,7 +343,7 @@ export class TrackingContentService {
               latest_content
           WHERE 
               row_num = 1;`,
-          [userId, searchFilter?.batchId],
+          [userId],
         );
         //find out details
         let output_result_details = [];
@@ -572,7 +566,6 @@ export class TrackingContentService {
         'userId',
         'courseId',
         'unitId',
-        'batchId',
         'contentId',
       ];
       const paginationKeys = ['pageSize', 'page'];
@@ -583,7 +576,6 @@ export class TrackingContentService {
         'userId',
         'courseId',
         'unitId',
-        'batchId',
         'contentId',
         'contentType',
         'contentMime',


### PR DESCRIPTION
Task #229704 Remove Batch ID Column from Content Tracking and Assessment Tracking Tables and Backend APIs in Tracking Microservice
https://tracker.tekdi.net/issues/229704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified data structures by removing the `batchId` property from various tracking-related classes, enhancing clarity and maintainability.
  
- **Bug Fixes**
	- Adjusted SQL queries in tracking services to exclude `batchId`, ensuring accurate data retrieval and processing.

- **Documentation**
	- Updated relevant documentation to reflect the removal of the `batchId` property in data transfer objects and service methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->